### PR TITLE
Fix: Prevents incorrect removal of language codes in URL aliases

### DIFF
--- a/plugins/sLangPlugin.php
+++ b/plugins/sLangPlugin.php
@@ -88,7 +88,11 @@ Event::listen('evolution.OnPageNotFound', function($params) {
 
                 if (in_array($url[0], sLang::langFront()) || (evo()->getLoginUserID('mgr') && in_array($url[0], sLang::langConfig()))) {
                     $langDefault = $url[0];
-                    $_SERVER['REQUEST_URI'] = str_replace($url[0] . '/', '', $_SERVER['REQUEST_URI']);
+                    // previous code
+                    //$_SERVER['REQUEST_URI'] = str_replace($url[0] . '/', '', $_SERVER['REQUEST_URI']);
+                    // Use preg_replace with a limit of 1 to ensure only the first occurrence of the language code is removed from the URL.
+                    // This prevents str_replace from incorrectly removing the same language code if it appears later in the page's alias, which would cause a 404 error.
+                    $_SERVER['REQUEST_URI'] = preg_replace('/' . $url[0] . '\//', '', $_SERVER['REQUEST_URI'], 1);
                 }
             }
         }


### PR DESCRIPTION
Update sLangPlugin.php
This commit resolves a bug where the sLang plugin's use of `str_replace` caused issues with URLs that included the language code in the alias.

By switching to `preg_replace` with a limit of 1, we ensure only the initial language directory is removed from the URL, fixing routing for pages like `website.url/es/some-url-es/` or `website.url/no/some-url-no/`  and preventing 404 errors.