### PR TITLE
Fix localized routes with friendly URL prefix and suffix

### DIFF
--- a/plugins/sLangPlugin.php
+++ b/plugins/sLangPlugin.php
@@ -107,15 +107,10 @@ Event::listen('evolution.OnPageNotFound', function() {
         evo()->setConfig('base_url', evo()->getConfig('base_url', '/') . $langDefault . '/');
     }
 
-    if (!isset($_SERVER['REQUEST_URI']) || !trim($_SERVER['REQUEST_URI']) || $_SERVER['REQUEST_URI'] == '/') {
-        $identifier = evo()->getConfig('site_start', 1);
-    } else {
-        $q = trim($_SERVER['REQUEST_URI'], '/');
-        $path = explode('?', $q);
-        $path = trim($path[0], evo()->getConfig('friendly_url_suffix', ''));
-        $path = trim($path, '/');
-        if (array_key_exists($path, UrlProcessor::getFacadeRoot()->documentListing)) {
-            $identifier = UrlProcessor::getFacadeRoot()->documentListing[$path];
+    if (isset($_SERVER['REQUEST_URI'])) {
+        $resolvedIdentifier = sLang::resolveLocalizedIdentifier((string)$_SERVER['REQUEST_URI']);
+        if (!is_null($resolvedIdentifier)) {
+            $identifier = $resolvedIdentifier;
         }
     }
 

--- a/src/sLang.php
+++ b/src/sLang.php
@@ -3,7 +3,9 @@
  * Class SeigerLang - Seiger Lang Management Module for Evolution CMS admin panel.
  */
 
+use EvolutionCMS\Facades\UrlProcessor;
 use EvolutionCMS\Models\SiteModule;
+use EvolutionCMS\Models\SiteContent;
 use EvolutionCMS\Models\SiteTmplvar;
 use EvolutionCMS\Models\SystemSetting;
 use Illuminate\Database\Eloquent\Builder;
@@ -262,6 +264,66 @@ class sLang
         }
 
         return $localizedPath . $query . $fragment;
+    }
+
+    /**
+     * Resolve a localized request URI to a document identifier.
+     *
+     * Uses Evolution's own friendly URL normalization so custom prefixes,
+     * suffixes, and alias paths are handled consistently.
+     */
+    public function resolveLocalizedIdentifier(string $requestUri): ?int
+    {
+        if ($requestUri === '' || $requestUri === '/') {
+            return (int)evo()->getConfig('site_start', 1);
+        }
+
+        $path = explode('?', trim($requestUri, '/'), 2);
+        $documentMethod = 'alias';
+        $query = UrlProcessor::cleanDocumentIdentifier($path[0], $documentMethod);
+        $prefix = (string)evo()->getConfig('friendly_url_prefix', '');
+        $documentListing = UrlProcessor::getFacadeRoot()->documentListing;
+
+        if ($documentMethod === 'id' && preg_match('/^[1-9]\d*$/', (string)$query)) {
+            return (int)$query;
+        }
+
+        if ($prefix !== '' && str_starts_with((string)$query, $prefix)) {
+            $query = substr((string)$query, strlen($prefix));
+        }
+
+        if (evo()->getConfig('use_alias_path') == 1) {
+            $virtualDir = UrlProcessor::getFacadeRoot()->virtualDir;
+            $alias = ($virtualDir !== '' ? $virtualDir . '/' : '') . $query;
+
+            if (isset($documentListing[$alias])) {
+                return (int)$documentListing[$alias];
+            }
+
+            if (evo()->getConfig('aliaslistingfolder') == 1 || evo()->getConfig('full_aliaslisting') == 1) {
+                $parent = $virtualDir ? UrlProcessor::getIdFromAlias($virtualDir) : 0;
+                $doc = SiteContent::select('id')
+                    ->where('deleted', 0)
+                    ->where('parent', $parent)
+                    ->where('alias', $query)
+                    ->first();
+
+                return is_null($doc) ? null : (int)$doc->getKey();
+            }
+
+            return null;
+        }
+
+        if (isset($documentListing[$query])) {
+            return (int)$documentListing[$query];
+        }
+
+        $doc = SiteContent::select('id')
+            ->where('deleted', 0)
+            ->where('alias', $query)
+            ->first();
+
+        return is_null($doc) ? null : (int)$doc->getKey();
     }
 
     /**


### PR DESCRIPTION
## Summary
- resolve localized request URIs through Evolution's friendly URL normalizer instead of manual suffix trimming
- support custom friendly URL suffixes like `.html` for non-default language routes
- support custom friendly URL prefixes, including nested alias-path resources

## Testing
- verified `resolveLocalizedIdentifier()` resolves `/target-page.html` and `/uk/target-page.html` to resource `2`
- verified `resolveLocalizedIdentifier()` resolves `/p-target-page` and `/uk/p-target-page` to resource `2`
- verified nested alias-path routes such as `/uk/minimal-base/p-child-page` resolve to resource `3`

Closes #4