### PR TITLE
Fix paginator URLs on non-default languages

### DIFF
--- a/src/sLang.php
+++ b/src/sLang.php
@@ -327,6 +327,40 @@ class sLang
     }
 
     /**
+     * Resolve the current request path for paginator URLs.
+     *
+     * Keeps the active frontend language segment in generated pagination links
+     * instead of falling back to the site root.
+     */
+    public function resolveCurrentPath(): string
+    {
+        $requestUri = (string)($_SERVER['REQUEST_URI'] ?? '/');
+        $path = (string)(parse_url($requestUri, PHP_URL_PATH) ?: '/');
+        $path = '/' . ltrim($path, '/');
+        $path = preg_replace('#/+#', '/', $path);
+
+        if ($path === '') {
+            $path = '/';
+        }
+
+        $siteUrl = (string)evo()->getConfig('site_url', EVO_SITE_URL);
+        $scheme = (string)parse_url($siteUrl, PHP_URL_SCHEME);
+        $host = (string)parse_url($siteUrl, PHP_URL_HOST);
+        $port = parse_url($siteUrl, PHP_URL_PORT);
+
+        if ($scheme === '' || $host === '') {
+            return $path;
+        }
+
+        $origin = $scheme . '://' . $host;
+        if (!is_null($port)) {
+            $origin .= ':' . $port;
+        }
+
+        return $origin . $path;
+    }
+
+    /**
      * Retrieves the language TVs.
      *
      * This method retrieves the language TVs from the configuration settings and

--- a/src/sLangServiceProvider.php
+++ b/src/sLangServiceProvider.php
@@ -2,6 +2,7 @@
 
 use EvolutionCMS\ServiceProvider;
 use Event;
+use Illuminate\Pagination\Paginator;
 
 class sLangServiceProvider extends ServiceProvider
 {
@@ -39,6 +40,10 @@ class sLangServiceProvider extends ServiceProvider
         // Class alias
         $this->app->singleton(sLang::class);
         $this->app->alias(sLang::class, 'sLang');
+
+        Paginator::currentPathResolver(function () {
+            return $this->app->make(sLang::class)->resolveCurrentPath();
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- set a localized paginator current path resolver in the sLang service provider
- use the original request URI so pagination links keep the active frontend language segment
- preserve nested localized route paths such as `/uk/blog/` in paginator URLs

## Testing
- verified Eloquent `paginate()` on `/uk/?page=2` returns paginator path `http://localhost./uk` with `previousPageUrl()` / `nextPageUrl()` staying under `/uk`
- verified Eloquent `paginate()` on `/uk/blog/?page=2` returns paginator path `http://localhost./uk/blog` with localized prev/next URLs

Closes #5