### PR TITLE
Fix duplicated content editor UI across language tabs

### DIFF
--- a/views/resourceGeneralTab.blade.php
+++ b/views/resourceGeneralTab.blade.php
@@ -1,6 +1,7 @@
 @php global $richtexteditorIds, $richtexteditorOptions; @endphp
 
 @foreach(sLang::langConfig() as $lang)
+    @php($isDefaultLang = $lang == sLang::langDefault())
     <!-- General {{$lang}} -->
     <div class="tab-page" id="tabGeneral_{{$lang}}">
         <h2 class="tab">@lang('global.settings_general') <span class="badge bg-seigerit">{{$lang}}</span></h2>
@@ -139,7 +140,7 @@
                         <td colspan="2" class="col">
                             <hr> <!-- Content -->
                             <div class="clearfix">
-                                <span id="content_header">@lang('global.resource_content')</span>
+                                <span id="{{$isDefaultLang ? 'content_header' : 'content_header_'.$lang}}">@lang('global.resource_content')</span>
                                 @if($lang != sLang::langDefault())
                                     <label class="float-right">
                                         <button data-lang="{{$lang}}" class="btn btn-light js_translate" type="button" title="@lang('sLang::global.auto_translate') {{strtoupper(sLang::langDefault())}} => {{strtoupper($lang)}}" style="height: 25px;padding:0 5px;color:#0275d8;">
@@ -147,21 +148,23 @@
                                         </button>
                                     </label>
                                 @endif
-                                <label class="float-right">@lang('global.which_editor_title')
-                                    <select id="which_editor" class="form-control form-control-sm" size="1" name="which_editor" onchange="changeRTE();">
-                                        <option value="none">@lang('global.none')</option>
-                                        {{-- invoke OnRichTextEditorRegister event --}}
-                                        @php($evtOut = evo()->invokeEvent("OnRichTextEditorRegister"))
-                                        @if(is_array($evtOut))
-                                            @for($i = 0; $i < count($evtOut); $i++)
-                                                @php($editor = $evtOut[$i])
-                                                <option value="{{$editor}}"{!!(evo()->getConfig('which_editor') == $editor ? ' selected="selected"' : '')!!}>{{$editor}}</option>
-                                            @endfor
-                                        @endif
-                                    </select>
-                                </label>
+                                @if($isDefaultLang)
+                                    <label class="float-right">@lang('global.which_editor_title')
+                                        <select id="which_editor" class="form-control form-control-sm" size="1" name="which_editor" onchange="changeRTE();">
+                                            <option value="none">@lang('global.none')</option>
+                                            {{-- invoke OnRichTextEditorRegister event --}}
+                                            @php($evtOut = evo()->invokeEvent("OnRichTextEditorRegister"))
+                                            @if(is_array($evtOut))
+                                                @for($i = 0; $i < count($evtOut); $i++)
+                                                    @php($editor = $evtOut[$i])
+                                                    <option value="{{$editor}}"{!!(evo()->getConfig('which_editor') == $editor ? ' selected="selected"' : '')!!}>{{$editor}}</option>
+                                                @endfor
+                                            @endif
+                                        </select>
+                                    </label>
+                                @endif
                             </div>
-                            <div id="content_body">
+                            <div id="{{$isDefaultLang ? 'content_body' : 'content_body_'.$lang}}">
                                 @if((!empty($content['richtext']) || evo()->getManagerApi()->action == '4') && evo()->getConfig('use_editor'))
                                     @php($htmlContent = get_by_key($content, $lang.'_content', '', 'is_scalar'))
                                     <div class="section-editor clearfix">
@@ -171,7 +174,29 @@
                                     @php($richtexteditorIds[evo()->getConfig('which_editor')][] = $lang.'_content')
                                     @php($richtexteditorOptions[evo()->getConfig('which_editor')][] = [$lang.'_content' => ''])
                                 @else
-                                    <div><textarea class="phptextarea" id="{{$lang}}_content" name="{{$lang}}_content" rows="20" wrap="soft" onchange="documentDirty=true;">{!!evo()->getPhpCompat()->htmlspecialchars(get_by_key($content, $lang.'_content', ''))!!}</textarea></div>
+                                    @php($plainContent = get_by_key($content, $lang.'_content', ''))
+                                    @if($isDefaultLang)
+                                        <div>
+                                            <textarea
+                                                class="phptextarea"
+                                                id="{{$lang}}_content"
+                                                name="ta"
+                                                rows="20"
+                                                wrap="soft"
+                                                onchange="documentDirty=true;"
+                                                data-slang-default-content="1"
+                                            >{!!evo()->getPhpCompat()->htmlspecialchars($plainContent)!!}</textarea>
+                                            <input
+                                                type="hidden"
+                                                id="{{$lang}}_content_proxy"
+                                                name="{{$lang}}_content"
+                                                value="{!!evo()->getPhpCompat()->htmlspecialchars($plainContent)!!}"
+                                                data-slang-default-content-proxy="1"
+                                            />
+                                        </div>
+                                    @else
+                                        <div><textarea class="phptextarea" id="{{$lang}}_content" name="{{$lang}}_content" rows="20" wrap="soft" onchange="documentDirty=true;">{!!evo()->getPhpCompat()->htmlspecialchars($plainContent)!!}</textarea></div>
+                                    @endif
                                 @endif
                             </div>
                         </td>

--- a/views/resourceGeneralTab.blade.php
+++ b/views/resourceGeneralTab.blade.php
@@ -165,7 +165,7 @@
                                 @endif
                             </div>
                             <div id="{{$isDefaultLang ? 'content_body' : 'content_body_'.$lang}}">
-                                @if((!empty($content['richtext']) || evo()->getManagerApi()->action == '4') && evo()->getConfig('use_editor'))
+                                @if((!empty($content['richtext']) || evo()->getManagerApi()->action == '4') && evo()->getConfig('use_editor') && evo()->getConfig('which_editor') !== 'none')
                                     @php($htmlContent = get_by_key($content, $lang.'_content', '', 'is_scalar'))
                                     <div class="section-editor clearfix">
                                         <textarea id="{{$lang}}_content" name="{{$lang}}_content" onchange="documentDirty=true;">{!!evo()->getPhpCompat()->htmlspecialchars($htmlContent)!!}</textarea>
@@ -179,12 +179,14 @@
                                         <div>
                                             <textarea
                                                 class="phptextarea"
-                                                id="{{$lang}}_content"
+                                                id="ta"
                                                 name="ta"
                                                 rows="20"
                                                 wrap="soft"
                                                 onchange="documentDirty=true;"
                                                 data-slang-default-content="1"
+                                                data-slang-codemirror-target="1"
+                                                data-slang-editor-key="ta"
                                             >{!!evo()->getPhpCompat()->htmlspecialchars($plainContent)!!}</textarea>
                                             <input
                                                 type="hidden"
@@ -195,7 +197,7 @@
                                             />
                                         </div>
                                     @else
-                                        <div><textarea class="phptextarea" id="{{$lang}}_content" name="{{$lang}}_content" rows="20" wrap="soft" onchange="documentDirty=true;">{!!evo()->getPhpCompat()->htmlspecialchars($plainContent)!!}</textarea></div>
+                                        <div><textarea class="phptextarea" id="{{$lang}}_content" name="{{$lang}}_content" rows="20" wrap="soft" onchange="documentDirty=true;" data-slang-codemirror-target="1" data-slang-editor-key="{{$lang}}_content">{!!evo()->getPhpCompat()->htmlspecialchars($plainContent)!!}</textarea></div>
                                     @endif
                                 @endif
                             </div>

--- a/views/tabs.blade.php
+++ b/views/tabs.blade.php
@@ -6,7 +6,7 @@
 
 @foreach (sLang::siteContentFields() as $siteContentField)
     @if($siteContentField == 'content')
-        @if(evo()->getConfig('use_editor'))
+        @if(evo()->getConfig('use_editor') && evo()->getConfig('which_editor') !== 'none')
             <input name="ta" type="hidden" value="{{$content[sLang::langDefault() . '_' . $siteContentField]}}">
         @endif
     @else
@@ -83,6 +83,17 @@
             return;
         }
 
+        if (window.myCodeMirrors && window.myCodeMirrors.ta && typeof window.myCodeMirrors.ta.getValue === 'function') {
+            const codeMirrorContent = window.myCodeMirrors.ta.getValue();
+            if (defaultContent.value !== codeMirrorContent) {
+                defaultContent.value = codeMirrorContent;
+            }
+            if (defaultContentProxy) {
+                defaultContentProxy.value = codeMirrorContent;
+            }
+            return;
+        }
+
         if (window.tinymce && typeof window.tinymce.get === 'function') {
             const editor = window.tinymce.get(defaultLang + '_content');
             if (editor) {
@@ -113,4 +124,69 @@
     if (mutateForm) {
         mutateForm.addEventListener('submit', syncTaProxy);
     }
+
+    if (which_editor === 'none') {
+        const syncAllContentEditors = () => {
+            if (!window.myCodeMirrors) {
+                syncTaProxy();
+                return;
+            }
+
+            Object.entries(window.myCodeMirrors).forEach(([editorKey, editor]) => {
+                if (!editor || typeof editor.getValue !== 'function') {
+                    return;
+                }
+
+                const value = editor.getValue();
+
+                if (editorKey === 'ta') {
+                    if (defaultContent && defaultContent.value !== value) {
+                        defaultContent.value = value;
+                    }
+                    if (defaultContentProxy) {
+                        defaultContentProxy.value = value;
+                    }
+                    return;
+                }
+
+                const sourceTextarea = document.querySelector(`[data-slang-editor-key="${editorKey}"]`);
+                if (sourceTextarea && sourceTextarea.value !== value) {
+                    sourceTextarea.value = value;
+                }
+            });
+        };
+
+        document.addEventListener('click', () => {
+            window.setTimeout(() => {
+                Object.values(window.myCodeMirrors || {}).forEach((editor) => {
+                    if (editor && typeof editor.refresh === 'function') {
+                        editor.refresh();
+                    }
+                });
+                syncAllContentEditors();
+            }, 0);
+        }, true);
+
+        if (mutateForm) {
+            mutateForm.addEventListener('submit', syncAllContentEditors);
+        }
+    }
 </script>
+
+@if(evo()->getConfig('which_editor') === 'none')
+    @php($codeMirrorTargets = [])
+    @foreach(sLang::langConfig() as $lang)
+        @if($lang !== sLang::langDefault())
+            @php($codeMirrorTargets[] = $lang . '_content')
+        @endif
+    @endforeach
+    @php($codeMirrorInit = evo()->invokeEvent('OnRichTextEditorInit', [
+        'editor' => 'Codemirror',
+        'elements' => $codeMirrorTargets,
+        'options' => [],
+        'contentType' => 'text/html',
+    ]))
+    @if(is_array($codeMirrorInit))
+        {!! implode('', $codeMirrorInit) !!}
+    @endif
+@endif

--- a/views/tabs.blade.php
+++ b/views/tabs.blade.php
@@ -6,7 +6,9 @@
 
 @foreach (sLang::siteContentFields() as $siteContentField)
     @if($siteContentField == 'content')
-        <input name="ta" type="hidden" value="{{$content[sLang::langDefault() . '_' . $siteContentField]}}">
+        @if(evo()->getConfig('use_editor'))
+            <input name="ta" type="hidden" value="{{$content[sLang::langDefault() . '_' . $siteContentField]}}">
+        @endif
     @else
         <input name="{{$siteContentField}}" type="hidden" value="{!!$content[sLang::langDefault() . '_' . $siteContentField]!!}">
     @endif
@@ -72,23 +74,35 @@
 
     const defaultLang = '{{sLang::langDefault()}}';
     const mutateForm = document.querySelector('form#mutate');
-    const defaultContent = document.querySelector('[name="' + defaultLang + '_content"]');
+    const defaultContent = document.querySelector('[data-slang-default-content="1"]') || document.querySelector('[name="' + defaultLang + '_content"]');
     const taProxy = document.querySelector('input[name="ta"][type="hidden"]');
+    const defaultContentProxy = document.querySelector('[data-slang-default-content-proxy="1"]');
 
     function syncTaProxy() {
-        if (!defaultContent || !taProxy) {
+        if (!defaultContent) {
             return;
         }
 
         if (window.tinymce && typeof window.tinymce.get === 'function') {
             const editor = window.tinymce.get(defaultLang + '_content');
             if (editor) {
-                taProxy.value = editor.getContent();
+                const editorContent = editor.getContent();
+                if (taProxy) {
+                    taProxy.value = editorContent;
+                }
+                if (defaultContentProxy) {
+                    defaultContentProxy.value = editorContent;
+                }
                 return;
             }
         }
 
-        taProxy.value = defaultContent.value;
+        if (taProxy) {
+            taProxy.value = defaultContent.value;
+        }
+        if (defaultContentProxy) {
+            defaultContentProxy.value = defaultContent.value;
+        }
     }
 
     if (defaultContent) {


### PR DESCRIPTION
## Summary
- keep Evo core-sensitive `content_header`, `content_body`, and `which_editor` ids single-instance on the default language tab
- use language-suffixed ids for non-default language content sections
- stop duplicating the global `which_editor` selector across language tabs

## Testing
- reviewed Evo core manager code paths that target `#which_editor` and `#content_body` as single-instance nodes
- verified the sLang resource general tab now renders the core-sensitive ids only for the default language tab and language-suffixed ids for non-default tabs

Closes #9