### PR TITLE
fix(sLang): remove srsltid from language links

### DIFF
--- a/src/sLang.php
+++ b/src/sLang.php
@@ -46,7 +46,9 @@ class sLang
         if (trim($sLangFront)) {
             $langFront = explode(',', $sLangFront);
         }
-        $baseUrl = $this->stripLanguageSegmentFromUri((string)request()->getRequestUri(), (string)evo()->getConfig('lang', 'uk'));
+        $baseUrl = $this->removeTrackingQueryParameters(
+            $this->stripLanguageSegmentFromUri((string)request()->getRequestUri(), (string)evo()->getConfig('lang', 'uk'))
+        );
         $result = [];
         foreach ($langFront as $item) {
             $result[$item] = $langList[$item];
@@ -449,6 +451,28 @@ class sLang
         $fragment = isset($parts['fragment']) ? '#' . $parts['fragment'] : '';
 
         return $path . $query . $fragment;
+    }
+
+    /**
+     * Remove known external tracking parameters from URLs generated for language alternatives.
+     *
+     * @since 1.1.0
+     */
+    protected function removeTrackingQueryParameters(string $uri): string
+    {
+        $parts = parse_url($uri);
+        if ($parts === false || empty($parts['query'])) {
+            return $uri;
+        }
+
+        parse_str($parts['query'], $query);
+        unset($query['srsltid'], $query['srsltiid']);
+
+        $path = (string)($parts['path'] ?? '');
+        $queryString = !empty($query) ? '?' . http_build_query($query) : '';
+        $fragment = isset($parts['fragment']) ? '#' . $parts['fragment'] : '';
+
+        return $path . $queryString . $fragment;
     }
 
     /**


### PR DESCRIPTION
## Problem
Google Merchant Center can append `srsltid` to incoming storefront URLs. `sLang::langSwitcher()` used the current request URI as-is, so that tracking parameter could be copied into language switcher links and alternate language URLs.

## Branch Reason
This is a package-level URL hygiene fix for `sLang`; it belongs in the package so consumers do not need project-local template workarounds.

## Change Summary
- Strip known external tracking query parameters from the request URI before building language switcher URLs.
- Preserve meaningful query parameters and fragments when rebuilding the URL.
- Keep the cleanup scoped to language alternative URL generation.

## Landing Surfaces
- `src/sLang.php`
- Language switcher links generated by `langSwitcher()`
- `hrefLang()` output because it reuses `langSwitcher()`

## Verification
- `git diff --check -- src/sLang.php`
- Reviewed the change against the PolyPro reproduction where `?srsltid=...` was repeated in language switcher links.

## Remaining Open Items
- PHP lint could not be run in the local Windows/WSL environment because no PHP runtime was available there.