### PR TITLE
Fix multilingual TVs in language content tabs

### DIFF
--- a/src/Controllers/sLangController.php
+++ b/src/Controllers/sLangController.php
@@ -785,7 +785,7 @@ class sLangController
                                     $richtexteditorIds[evo()->getConfig('which_editor')][] = "tv" . $temp_row['id'];
                                     $richtexteditorOptions[evo()->getConfig('which_editor')]["tv" . $temp_row['id']] = '';
                                 }
-                                $templateVariablesTab[$tab][] = $this->view('partials.tvResource', [
+                                $templateVariable = $this->view('partials.tvResource', [
                                     '_lang' => $_lang,
                                     '_style' => $_style,
                                     'row' => $temp_row,
@@ -793,6 +793,12 @@ class sLangController
                                     'tvsArray' => $tvsArray,
                                     'content' => $content,
                                 ])->render();
+
+                                if ($group_tvs < 3) {
+                                    $templateVariablesLng[$tab][] = $templateVariable;
+                                } else {
+                                    $templateVariablesTab[$tab][] = $templateVariable;
+                                }
                             }
                         } else {
                             if ($row['type'] == 'richtext') {
@@ -836,12 +842,6 @@ class sLangController
                 if (!$group_tvs) {
                     $str = '<div class="sectionHeader" id="tv_header">' . $_lang['settings_templvars'] . '</div><div class="sectionBody tmplvars">';
                     $templateVariables .= $str;
-
-                    if (count($templateVariablesLng)) {
-                        foreach ($templateVariablesLng as $lng => $item) {
-                            $templateVariablesLng[$lng][0] .= $str;
-                        }
-                    }
                 } else if ($group_tvs == 2) {
                     $templateVariables .= '
                     <div class="tab-section">
@@ -870,7 +870,7 @@ class sLangController
                     $templateVariables .= $templateVariablesOutput;
                     $templateVariables .= '</div>' . "\n";
 
-                    if (count($templateVariablesLng)) {
+                    if ($group_tvs && count($templateVariablesLng)) {
                         foreach ($templateVariablesLng as $lng => $item) {
                             array_push($templateVariablesLng[$lng], '</div>' . "\n");
                         }


### PR DESCRIPTION
## Problem
Multilingual TVs configured through sLang were always placed on separate “Template Variables” tabs. When Evolution CMS uses a content-oriented TV layout (`group_tvs` below `3`), this leaves the language content tabs without those fields.

## Why
Editors expect multilingual fields, including MultiFields constructors, directly inside the matching language content tab in content-oriented manager layouts.

## What Changed
- Render multilingual TV fragments into the corresponding language fragment when `group_tvs < 3`
- Keep dedicated TV tabs unchanged for tab-oriented layouts
- Remove the legacy “Template Variables” header and wrapper from language content fragments

## Where
`src/Controllers/sLangController.php`

## Verification
- Confirmed the content-oriented branch routes each multilingual TV to `templateVariablesLng`
- Confirmed the tab-oriented branch keeps routing to `templateVariablesTab`
- Confirmed the legacy language wrapper is absent
- `git diff --check` passed

## Remaining Gaps
PHP CLI is unavailable in this environment, so package runtime tests were not executed locally. The behavior was manually verified in the MAUP Library manager before this package PR.