### PR TITLE
fix(sLang): prevent duplicate language URL prefixes

### DIFF
--- a/plugins/sLangPlugin.php
+++ b/plugins/sLangPlugin.php
@@ -111,7 +111,10 @@ Event::listen('evolution.OnPageNotFound', function() {
     evo()->setConfig('lang', $langDefault);
 
     if (sLang::langDefault() != $langDefault || sLang::defaultInUrl()) {
-        evo()->setConfig('base_url', evo()->getConfig('base_url', '/') . sLang::langSegment($langDefault) . '/');
+        evo()->setConfig(
+            'base_url',
+            sLang::localizeGeneratedUrl((string)evo()->getConfig('base_url', '/'), $langDefault)
+        );
     }
 
     if ($requestUri !== '') {
@@ -172,7 +175,10 @@ Event::listen('evolution.OnLoadSettings', function($params) {
     evo()->setConfig('lang', $langDefault);
 
     if (sLang::langDefault() != $langDefault || sLang::defaultInUrl()) {
-        evo()->setConfig('base_url', evo()->getConfig('base_url', '/') . sLang::langSegment($langDefault) . '/');
+        evo()->setConfig(
+            'base_url',
+            sLang::localizeGeneratedUrl((string)evo()->getConfig('base_url', '/'), $langDefault)
+        );
     }
 
     if (!is_null($resolvedLocale) && isset($_REQUEST['q'])) {


### PR DESCRIPTION
## Problem

Localized requests that pass through `OnPageNotFound`, including virtual product routes and the localized home page, can append the active language segment to `base_url` twice. Generated links then contain paths such as `/ru/ru/...`.

## Why

Both `OnLoadSettings` and `OnPageNotFound` mutate `base_url` by concatenating the language segment. When both events run during one request, the second mutation is not idempotent.

## What Changed

Use the existing `sLang::localizeGeneratedUrl()` helper when updating `base_url` in both event handlers. The helper preserves an existing locale prefix instead of adding it again.

## Where

- `plugins/sLangPlugin.php`

## Verification

- Reproduced in an Evolution CMS consumer on localized product and home routes.
- Applied the same patch to the installed package copy; the consumer runtime check confirmed that generated links no longer contain the duplicated language segment.
- Confirmed the package patch exactly matches the runtime-verified installed copy.
- `git diff --check` passes.

## Remaining Gaps

The current `2.x` branch contains the same non-idempotent `base_url` mutations and should receive an equivalent branch-specific fix. This PR intentionally targets `1.x` only.

The package has no local automated test suite, and PHP CLI was unavailable in the current execution environment.